### PR TITLE
Fix http scheme for Branch deeplinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.12.2] - 2023-02-16
+
+### Fixed
+
+- Http scheme for Branch.io deeplink
 
 ## [3.12.1] - 2023-02-16
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,7 +64,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" android:host="hypertrack-live.app.link" />
-                <data android:scheme="https" android:host="hypertrack-live.app.link" />
+                <data android:scheme="http" android:host="hypertrack-live.app.link" />
             </intent-filter>
 
         </activity>

--- a/build.gradle
+++ b/build.gradle
@@ -27,4 +27,4 @@ allprojects {
 
 task clean(type: Delete) { delete rootProject.buildDir }
 
-version = "3.12.2"
+version = "3.13.0-SNAPSHOT"

--- a/build.gradle
+++ b/build.gradle
@@ -27,4 +27,4 @@ allprojects {
 
 task clean(type: Delete) { delete rootProject.buildDir }
 
-version = "3.13.0-SNAPSHOT"
+version = "3.12.2"


### PR DESCRIPTION
The scheme was mistakenly set up as https